### PR TITLE
adds GET /api/articles feature with passing tests

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,10 +2,13 @@ const express = require("express");
 const app = express();
 const { getApi } = require("./controllers/api-controllers");
 const { getTopics } = require("./controllers/topic-controllers");
-const { getArticle } = require("./controllers/article-controllers");
-app.use(express.json());
+const {
+  getArticle,
+  getAllArticles,
+} = require("./controllers/article-controllers");
 app.get("/api/", getApi);
 app.get("/api/topics", getTopics);
+app.get("/api/articles", getAllArticles);
 app.get("/api/articles/:article_id", getArticle);
 
 app.use((request, response, next) => {

--- a/controllers/article-controllers.js
+++ b/controllers/article-controllers.js
@@ -1,4 +1,10 @@
-const { fetchArticle } = require("../models/article-models");
+const { fetchArticle, fetchAllArticles } = require("../models/article-models");
+
+const getAllArticles = (request, response, next) => {
+  fetchAllArticles().then((articles) => {
+    response.status(200).send({ articles: articles });
+  });
+};
 
 const getArticle = (request, response, next) => {
   const { article_id } = request.params;
@@ -11,4 +17,4 @@ const getArticle = (request, response, next) => {
     });
 };
 
-module.exports = { getArticle };
+module.exports = { getArticle, getAllArticles };

--- a/endpoints.json
+++ b/endpoints.json
@@ -16,12 +16,13 @@
     "exampleResponse": {
       "articles": [
         {
+          "author": "Mr_smith",
           "title": "Seafood substitutions are increasing",
+          "article_id": "10",
           "topic": "cooking",
-          "author": "weegembump",
-          "body": "Text from the article..",
           "created_at": "2018-05-30T15:59:13.341Z",
           "votes": 0,
+          "article_img_url": "https://images.pexels.com/photos/122242/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
           "comment_count": 6
         }
       ]

--- a/models/article-models.js
+++ b/models/article-models.js
@@ -1,5 +1,16 @@
 const db = require("../db/connection");
 
+const fetchAllArticles = () => {
+  return db.query(`SELECT 
+  articles.author, articles.title, articles.article_id, articles.topic,
+  articles.created_at,articles.votes,articles.article_img_url, 
+  COUNT(comments.comment_id) AS comment_count
+  FROM articles
+  LEFT JOIN comments ON articles.article_id = comments.article_id
+  GROUP BY articles.article_id
+  ORDER BY articles.created_at DESC`);
+};
+
 const fetchArticle = (article_id) => {
   return db
     .query(
@@ -19,4 +30,4 @@ const fetchArticle = (article_id) => {
     });
 };
 
-module.exports = { fetchArticle };
+module.exports = { fetchArticle, fetchAllArticles };

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "husky": "^8.0.2",
         "jest": "^27.5.1",
         "jest-extended": "^2.0.0",
+        "jest-sorted": "^1.0.14",
         "pg-format": "^1.0.4"
       }
     },
@@ -3156,6 +3157,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/jest-sorted": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/jest-sorted/-/jest-sorted-1.0.14.tgz",
+      "integrity": "sha512-qGMA3ybF15S+4gDtv3XaE/GtEd3YvSepVC3vL63TbxIISkeOS/0HhRZYL12VQGKn0TWyi2/62dh5OO71X9LY3A==",
+      "dev": true
     },
     "node_modules/jest-util": {
       "version": "27.5.1",
@@ -7377,6 +7384,12 @@
           }
         }
       }
+    },
+    "jest-sorted": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/jest-sorted/-/jest-sorted-1.0.14.tgz",
+      "integrity": "sha512-qGMA3ybF15S+4gDtv3XaE/GtEd3YvSepVC3vL63TbxIISkeOS/0HhRZYL12VQGKn0TWyi2/62dh5OO71X9LY3A==",
+      "dev": true
     },
     "jest-util": {
       "version": "27.5.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "husky": "^8.0.2",
     "jest": "^27.5.1",
     "jest-extended": "^2.0.0",
+    "jest-sorted": "^1.0.14",
     "pg-format": "^1.0.4"
   },
   "dependencies": {
@@ -34,7 +35,8 @@
   },
   "jest": {
     "setupFilesAfterEnv": [
-      "jest-extended/all"
+      "jest-extended/all",
+      "jest-sorted"
     ]
   }
 }


### PR DESCRIPTION
Refactored my previous generic 404 tests to catch incorrect paths in each block into a single test for all incorrect paths as recommended in today's lecture. 